### PR TITLE
reword student count error msg

### DIFF
--- a/app/forms/courses/bulk_import_students_form.rb
+++ b/app/forms/courses/bulk_import_students_form.rb
@@ -45,7 +45,7 @@ module Courses
     def soft_limit_student_count
       return if csv_rows.count <= 1000
 
-      errors[:base] << "You can only onboard less than 1000 students at a time"
+      errors[:base] << "You can only onboard 1000 students at a time"
     end
 
     def valid_string?(string:, max_length:, optional: false)


### PR DESCRIPTION
assuming I understand this error correctly, the interface allows for UP TO 1000 students to be onboarded at a time. Therefore, the original msg is a little confusing for the user

## Proposed Changes

- delete "less than" from soft limit student count error msg
